### PR TITLE
update makefile account reference value to axiomzen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DIST := dist
 EXECUTABLE := gorush
 
 GO ?= go
-DEPLOY_ACCOUNT := appleboy
+DEPLOY_ACCOUNT := axiomzen
 DEPLOY_IMAGE := $(EXECUTABLE)
 GOFMT ?= gofmt "-s"
 


### PR DESCRIPTION
So that running commands such as `make docker_image` build for `axiomzen/gorush` and not `appleboy/gorush`